### PR TITLE
Fixes for Azure Automation module 

### DIFF
--- a/src/ResourceManager/Automation/Commands.Automation/Cmdlet/AzureAutomationBaseCmdlet.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Cmdlet/AzureAutomationBaseCmdlet.cs
@@ -90,13 +90,10 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
                 {
                     if (!string.IsNullOrEmpty(ErrorResponseException.Response.Content))
                     {
-                        if (IsValidJsonObject(ErrorResponseException.Response.Content))
+                        var message = ParseJson(ErrorResponseException.Response.Content);
+                        if (!string.IsNullOrEmpty(message))
                         {
-                            var message = ParseJson(ErrorResponseException.Response.Content);
-                            if (!string.IsNullOrEmpty(message))
-                            {
-                                throw new ErrorResponseException(message, ErrorResponseException);
-                            }
+                            throw new ErrorResponseException(message, ErrorResponseException);
                         }
                     }
                 }
@@ -113,7 +110,7 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
             value = value.Trim();
             try
             {
-                var nestedError = JsonConvert.DeserializeObject<AzureAutomationNestedErrorResponseMessage>(value);
+                var nestedError = JsonConvert.DeserializeObject<AzureAutomationErrorResponseMessage>(value);
                 return nestedError.Error.Message;
             }
             catch
@@ -123,7 +120,7 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
 
             try
             {
-                var error = JsonConvert.DeserializeObject<AzureAutomationErrorResponseMessage>(value);
+                var error = JsonConvert.DeserializeObject<AzureAutomationErrorInfo>(value);
                 return error.Message;
             }
             catch
@@ -166,26 +163,6 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
             }
 
             return ret;
-        }
-
-        // This function determines if the given value is a Json object.
-        private bool IsValidJsonObject(string value)
-        {
-            value = value.Trim();
-            if (value.StartsWith("{") && value.EndsWith("}"))
-            {
-                try
-                {
-                    var result = JObject.Parse(value);
-                    return true;
-                }
-                catch
-                {
-                    // ignore the failure
-                    return false;
-                }
-            }
-            return false;
         }
     }
 }

--- a/src/ResourceManager/Automation/Commands.Automation/Cmdlet/GetAzureAutomationSourceControlSyncJobOutput.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Cmdlet/GetAzureAutomationSourceControlSyncJobOutput.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Commands.Automation.Cmdlet
         public string SourceControlName { get; set; }
 
         /// <summary> 
-        /// Gets or sets the source contorl sync job id. 
+        /// Gets or sets the source control sync job id.
         /// </summary> 
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true,
                    HelpMessage = "The source control sync job id.")]

--- a/src/ResourceManager/Automation/Commands.Automation/Commands.Automation.csproj
+++ b/src/ResourceManager/Automation/Commands.Automation/Commands.Automation.csproj
@@ -148,9 +148,9 @@
     <Compile Include="Common\AutomationPSClientSourceControl.cs" />
     <Compile Include="Common\AutomationPSClientWebhook.cs" />
     <Compile Include="Common\AutomationCmdletParameterSet.cs" />
-    <Compile Include="Common\AzureAutomationNestedErrorResponseMessage.cs" />
-    <Compile Include="Common\AzureAutomationOperationException.cs" />
+    <Compile Include="Common\AzureAutomationErrorInfo.cs" />
     <Compile Include="Common\AzureAutomationErrorResponseMessage.cs" />
+    <Compile Include="Common\AzureAutomationOperationException.cs" />
     <Compile Include="Common\Constants.cs" />
     <Compile Include="Common\DscNodeStatus.cs" />
     <Compile Include="Common\IAutomationPSClient.cs" />

--- a/src/ResourceManager/Automation/Commands.Automation/Commands.Automation.csproj
+++ b/src/ResourceManager/Automation/Commands.Automation/Commands.Automation.csproj
@@ -148,7 +148,9 @@
     <Compile Include="Common\AutomationPSClientSourceControl.cs" />
     <Compile Include="Common\AutomationPSClientWebhook.cs" />
     <Compile Include="Common\AutomationCmdletParameterSet.cs" />
+    <Compile Include="Common\AzureAutomationNestedErrorResponseMessage.cs" />
     <Compile Include="Common\AzureAutomationOperationException.cs" />
+    <Compile Include="Common\AzureAutomationErrorResponseMessage.cs" />
     <Compile Include="Common\Constants.cs" />
     <Compile Include="Common\DscNodeStatus.cs" />
     <Compile Include="Common\IAutomationPSClient.cs" />
@@ -263,7 +265,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-</ItemGroup>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\tools\Common.Dependencies.targets" />
   <Target Name="AfterBuild">

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AutomationPSClientWebhook.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AutomationPSClientWebhook.cs
@@ -18,6 +18,7 @@ using Microsoft.Azure.Management.Automation.Models;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Rest.Azure.OData;
 
 namespace Microsoft.Azure.Commands.Automation.Common
 {
@@ -120,10 +121,11 @@ namespace Microsoft.Azure.Commands.Automation.Common
                     }
                     else
                     {
+                        var filter = GetRunbookNameFilterString(runbookName);
                         response = this.automationManagementClient.Webhook.ListByAutomationAccount(
                             resourceGroupName,
                             automationAccountName,
-                            runbookName);
+                            new ODataQuery<Webhook>(filter));
                     }
                 }
                 else
@@ -200,6 +202,24 @@ namespace Microsoft.Azure.Commands.Automation.Common
                     throw;
                 }
             }
+        }
+
+        private string GetRunbookNameFilterString(string runbookName)
+        {
+            string filter = null;
+            List<string> odataFilter = new List<string>();
+
+            if (!string.IsNullOrWhiteSpace(runbookName))
+            {
+                odataFilter.Add("properties/runbook/name eq '" + Uri.EscapeDataString(runbookName) + "'");
+            }
+
+            if (odataFilter.Count > 0)
+            {
+                filter = string.Join(" and ", odataFilter);
+            }
+
+            return filter;
         }
     }
 }

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationErrorInfo.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationErrorInfo.cs
@@ -19,28 +19,21 @@ namespace Microsoft.Azure.Commands.Automation.Common
     /// <summary>
     /// The error response message.
     /// </summary>
-    public class AzureAutomationNestedErrorResponseMessage
+    public class AzureAutomationErrorInfo
     {
-        // Gets or sets the extended error info.
+        // Gets or sets the error code.
         [JsonProperty(Required = Required.Default)]
-        public AzureAutomationErrorInfo Error { get; set; }
+        public string Code { get; set; }
+
+        // Gets or sets the error message.
+        [JsonProperty(Required = Required.Default)]
+        public string Message { get; set; }
 
         // Initializes a new instance of the class.
-        public AzureAutomationNestedErrorResponseMessage(string code, string message)
+        public AzureAutomationErrorInfo(string code, string message)
         {
-            this.Error = new AzureAutomationErrorInfo { Code = code, Message = message };
-        }
-
-        /// The error information.
-        public class AzureAutomationErrorInfo
-        {
-            // Gets or sets the error code.
-            [JsonProperty(Required = Required.Default)]
-            public string Code { get; set; }
-
-            // Gets or sets the error message.
-            [JsonProperty(Required = Required.Default)]
-            public string Message { get; set; }
+            this.Code = code;
+            this.Message = message;
         }
     }
 }

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationErrorResponseMessage.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationErrorResponseMessage.cs
@@ -1,0 +1,39 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Commands.Automation.Common
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// The error response message.
+    /// </summary>
+    public class AzureAutomationErrorResponseMessage
+    {
+        // Gets or sets the error code.
+        [JsonProperty(Required = Required.Default)]
+        public string Code { get; set; }
+
+        // Gets or sets the error message.
+        [JsonProperty(Required = Required.Default)]
+        public string Message { get; set; }
+
+        // Initializes a new instance of the class.
+        public AzureAutomationErrorResponseMessage(string code, string message)
+        {
+            this.Code = code;
+            this.Message = message;
+        }
+    }
+}

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationErrorResponseMessage.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationErrorResponseMessage.cs
@@ -21,19 +21,14 @@ namespace Microsoft.Azure.Commands.Automation.Common
     /// </summary>
     public class AzureAutomationErrorResponseMessage
     {
-        // Gets or sets the error code.
+        // Gets or sets the extended error info.
         [JsonProperty(Required = Required.Default)]
-        public string Code { get; set; }
-
-        // Gets or sets the error message.
-        [JsonProperty(Required = Required.Default)]
-        public string Message { get; set; }
+        public AzureAutomationErrorInfo Error { get; set; }
 
         // Initializes a new instance of the class.
         public AzureAutomationErrorResponseMessage(string code, string message)
         {
-            this.Code = code;
-            this.Message = message;
+            this.Error = new AzureAutomationErrorInfo(code, message);
         }
     }
 }

--- a/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationNestedErrorResponseMessage.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Common/AzureAutomationNestedErrorResponseMessage.cs
@@ -1,0 +1,46 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Commands.Automation.Common
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// The error response message.
+    /// </summary>
+    public class AzureAutomationNestedErrorResponseMessage
+    {
+        // Gets or sets the extended error info.
+        [JsonProperty(Required = Required.Default)]
+        public AzureAutomationErrorInfo Error { get; set; }
+
+        // Initializes a new instance of the class.
+        public AzureAutomationNestedErrorResponseMessage(string code, string message)
+        {
+            this.Error = new AzureAutomationErrorInfo { Code = code, Message = message };
+        }
+
+        /// The error information.
+        public class AzureAutomationErrorInfo
+        {
+            // Gets or sets the error code.
+            [JsonProperty(Required = Required.Default)]
+            public string Code { get; set; }
+
+            // Gets or sets the error message.
+            [JsonProperty(Required = Required.Default)]
+            public string Message { get; set; }
+        }
+    }
+}

--- a/src/ResourceManager/Automation/Commands.Automation/Model/JobSchedule.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Model/JobSchedule.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Commands.Automation.Model
             Requires.Argument("jobSchedule", jobSchedule).NotNull();
             this.ResourceGroupName = resourceGroupName;
             this.AutomationAccountName = automationAccountName;
-            this.JobScheduleId = jobSchedule.Id.ToString();
+            this.JobScheduleId = jobSchedule.JobScheduleId.ToString();
             this.RunbookName = jobSchedule.Runbook.Name;
             this.ScheduleName = jobSchedule.Schedule.Name;
             this.Parameters = new Hashtable(StringComparer.InvariantCultureIgnoreCase);

--- a/src/ResourceManager/Automation/Commands.Automation/Properties/Resources.Designer.cs
+++ b/src/ResourceManager/Automation/Commands.Automation/Properties/Resources.Designer.cs
@@ -793,16 +793,8 @@ namespace Microsoft.Azure.Commands.Automation.Properties {
         ///   Looks up a localized string similar to Software update configuration has no target computers..
         /// </summary>
         internal static string SoftwareUpdateConfigurationHasNoTargetComputers {
-            get
-            {
-                return ResourceManager.GetString("SoftwareUpdateConfigurationHasNoTargetComputers", resourceCulture);
-            }
-        }
-        ///   Looks up a localized string similar to SourceControl &apos;{0}&apos; already exists..
-        /// </summary>
-        internal static string SourceControlAlreadyExists {
             get {
-                return ResourceManager.GetString("SourceControlAlreadyExists", resourceCulture);
+                return ResourceManager.GetString("SoftwareUpdateConfigurationHasNoTargetComputers", resourceCulture);
             }
         }
         
@@ -812,15 +804,6 @@ namespace Microsoft.Azure.Commands.Automation.Properties {
         internal static string SourceControlCreateAction {
             get {
                 return ResourceManager.GetString("SourceControlCreateAction", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SourceControl &apos;{0}&apos; not found..
-        /// </summary>
-        internal static string SourceControlNotFound {
-            get {
-                return ResourceManager.GetString("SourceControlNotFound", resourceCulture);
             }
         }
         
@@ -839,42 +822,6 @@ namespace Microsoft.Azure.Commands.Automation.Properties {
         internal static string SourceControlRemoveWarning {
             get {
                 return ResourceManager.GetString("SourceControlRemoveWarning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SourceControl RepoUrl cannot be changed..
-        /// </summary>
-        internal static string SourceControlRepoUrlCannotBeChanged {
-            get {
-                return ResourceManager.GetString("SourceControlRepoUrlCannotBeChanged", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SourceControl SyncJob with id: &apos;{0}&apos; already exists..
-        /// </summary>
-        internal static string SourceControlSyncJobAlreadyExist {
-            get {
-                return ResourceManager.GetString("SourceControlSyncJobAlreadyExist", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SourceControl Sync Job with id: &apos;{0}&apos; not found..
-        /// </summary>
-        internal static string SourceControlSyncJobNotFound {
-            get {
-                return ResourceManager.GetString("SourceControlSyncJobNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SourceControl Type cannot be changed..
-        /// </summary>
-        internal static string SourceControlTypeCannotBeChanged {
-            get {
-                return ResourceManager.GetString("SourceControlTypeCannotBeChanged", resourceCulture);
             }
         }
         

--- a/src/ResourceManager/Automation/Commands.Automation/Properties/Resources.resx
+++ b/src/ResourceManager/Automation/Commands.Automation/Properties/Resources.resx
@@ -470,22 +470,6 @@
   <data name="SoftwareUpdateConfigurationHasNoTargetComputers" xml:space="preserve">
     <value>Software update configuration has no target computers.</value>
   </data>
-  <data name="SourceControlAlreadyExists" xml:space="preserve">
-    <value>SourceControl '{0}' already exists.</value>
-    <comment>Automation</comment>
-  </data>
-  <data name="SourceControlNotFound" xml:space="preserve">
-    <value>SourceControl '{0}' not found.</value>
-    <comment>Automation</comment>
-  </data>
-  <data name="SourceControlRepoUrlCannotBeChanged" xml:space="preserve">
-    <value>SourceControl RepoUrl cannot be changed.</value>
-    <comment>Automation</comment>
-  </data>
-  <data name="SourceControlTypeCannotBeChanged" xml:space="preserve">
-    <value>SourceControl Type cannot be changed.</value>
-    <comment>Automation</comment>
-  </data>
   <data name="SourceControlCreateAction" xml:space="preserve">
     <value>Creating Azure Automation Source Control.</value>
     <comment>Automation</comment>
@@ -496,14 +480,6 @@
   </data>
   <data name="SourceControlRemoveWarning" xml:space="preserve">
     <value>Are you sure you want to remove the Azure Automation Source Control?</value>
-  </data>
-  <data name="SourceControlSyncJobAlreadyExist" xml:space="preserve">
-    <value>SourceControl SyncJob with id: '{0}' already exists.</value>
-    <comment>Automation</comment>
-  </data>
-  <data name="SourceControlSyncJobNotFound" xml:space="preserve">
-    <value>SourceControl Sync Job with id: '{0}' not found.</value>
-    <comment>Automation</comment>
   </data>
   <data name="SourceControlUpdateAction" xml:space="preserve">
     <value>Updating the Azure Automation Source Control.</value>


### PR DESCRIPTION
This PR contains the following fixes:

- Fixing odata filter for getting a webhook by runbook name
- Fixing JobSchedule by setting the correct JobScheduleId
- Fixing exception handling for source control cmdlets
- Adding logic to ExecuteCmdlet, so that when a ErrorResponseException is thrown, we check to see if ErrorResponseException.Body.Message is available. If not, we try to extracted from error message from ErrorResponseException.Response.Content, and we rethrow again using the extracted message. With this fix, the correct error message for invalid ResourceGroupName and AutomationAccountName is displayed to the user.